### PR TITLE
fix(lastFmRpc): use SelfPresenceStore

### DIFF
--- a/src/lastFmRpc/webpackModules/presence.ts
+++ b/src/lastFmRpc/webpackModules/presence.ts
@@ -1,5 +1,5 @@
 import Dispatcher from "@moonlight-mod/wp/discord/Dispatcher";
-import { PresenceStore } from "@moonlight-mod/wp/common_stores";
+import { SelfPresenceStore } from "@moonlight-mod/wp/common_stores";
 import spacepack from "@moonlight-mod/wp/spacepack_spacepack";
 
 const ApplicationAssetUtils = spacepack.findByCode("getAssetImage: size must === [")[0];
@@ -154,14 +154,14 @@ const getLargeImage = (track: TrackData): string | undefined => {
 
 const getActivity = async (): Promise<Activity | null> => {
   if (getOpt<boolean>("hideWithActivity")) {
-    if (PresenceStore.getActivities().some((a: { application_id: string }) => a.application_id !== applicationId)) {
+    if (SelfPresenceStore.getActivities().some((a: { application_id: string }) => a.application_id !== applicationId)) {
       return null;
     }
   }
 
   if (getOpt<boolean>("hideWithSpotify")) {
     if (
-      PresenceStore.getActivities().some(
+      SelfPresenceStore.getActivities().some(
         (a: { type: ActivityType; application_id: string }) =>
           a.type === ActivityType.LISTENING && a.application_id !== applicationId
       )


### PR DESCRIPTION
The original Vencord extension looks for `SelfPresenceStore` though it stored it in a variable called `PresenceStore`, and as it also exposes a getActivities method which does not directly fail without arguments, this led to the 'hide with other listening status' option silently failing.

(as discussed a few days ago, submitting this fix to the GH mirror. locally tested, it builds and runs fine and the issue seems fixed~ unrelatedly i was thinking of correcting the phrasing from 'hide with spotify' to 'hide with other listening status' but that's best suited for another PR)